### PR TITLE
Fix missing variable when adding knowledge base

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -165,6 +165,7 @@ def add_knowledge_base_to_agent(
     if len(provided_params) > 1:
         make_error("Must provide exactly one of: URL, file, or text")
 
+    file = None
     if url is not None:
         response = client.conversational_ai.knowledge_base.documents.create_from_url(
             name=knowledge_base_name,


### PR DESCRIPTION
## Summary
- ensure `file` variable is initialized in `add_knowledge_base_to_agent`

## Testing
- `./scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68756a48a1fc832ca5064b0193d9032e