### PR TITLE
Add non-audio check test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,3 +87,14 @@ def test_handle_input_file():
 
         with pytest.raises(ElevenLabsMcpError):
             handle_input_file(str(temp_path / "nonexistent.mp3"))
+
+def test_handle_input_file_non_audio_error():
+    """Ensure non-audio files raise an error when audio_content_check is True."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        text_file = temp_path / "test.txt"
+        text_file.write_text("dummy text")
+
+        with pytest.raises(ElevenLabsMcpError):
+            handle_input_file(str(text_file), audio_content_check=True)
+


### PR DESCRIPTION
## Summary
- ensure `handle_input_file` raises when given a non-audio file

## Testing
- `scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68759fd119b4832c91cf93284a8f2ff0